### PR TITLE
Update x/tools to fix panic in tests with Go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.18
 
 require (
 	github.com/magefile/mage v1.14.0
-	golang.org/x/tools v0.3.0
+	golang.org/x/tools v0.13.0
 )
 
 require (
-	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/mod v0.12.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
 github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/tools v0.3.0 h1:SrNbZl6ECOS1qFzgTdQfWXZM9XBkiA6tkFrH9YSTPHM=
-golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
+golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
+golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=


### PR DESCRIPTION
This PR fixes panic in tests when running with Go 1.23.

<details><summary>Details</summary>
<p>

```
?   	github.com/curioswitch/go-reassign	[no test files]
?   	github.com/curioswitch/go-reassign/cmd	[no test files]
?   	github.com/curioswitch/go-reassign/magefiles	[no test files]
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1031d96a4]

goroutine 131 [running]:
go/types.(*Checker).handleBailout(0x14000482540, 0x140004b3c08)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:404 +0x9c
panic({0x1032f2500?, 0x1034d4540?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/runtime/panic.go:785 +0x124
go/types.(*StdSizes).Sizeof(0x0, {0x103340008, 0x1034d7a80})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:229 +0x314
go/types.(*Config).sizeof(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/sizes.go:334
go/types.representableConst.func1({0x103340008?, 0x1034d7a80?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:77 +0x90
go/types.representableConst({0x103341768, 0x1034cbd18}, 0x14000482540, 0x1034d7a80, 0x140004b29e8)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:93 +0x134
go/types.(*Checker).representation(0x14000482540, 0x1400053ec80, 0x1034d7a80)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/const.go:257 +0x68
go/types.(*Checker).implicitTypeAndValue(0x14000482540, 0x1400053ec80, {0x103340008, 0x1034d7a80})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:377 +0x304
go/types.(*Checker).assignment(0x14000482540, 0x1400053ec80, {0x103340008, 0x1034d7a80}, {0x10325585b, 0xe})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/assignments.go:70 +0x3ac
go/types.(*Checker).exprInternal(0x14000482540, 0x0, 0x1400053ec80, {0x103340b68, 0x140004a8300}, {0x103340058, 0x1400063a000})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1211 +0x1810
go/types.(*Checker).rawExpr(0x14000482540, 0x0, 0x1400053ec80, {0x103340b68?, 0x140004a8300?}, {0x103340058?, 0x1400063a000?}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).exprWithHint(0x14000482540, 0x1400053ec80, {0x103340b68, 0x140004a8300}, {0x103340058, 0x1400063a000})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1599 +0x64
go/types.(*Checker).indexedElts(0x14000482540, {0x140004c8008, 0x24, 0x14000499a70?}, {0x103340058, 0x1400063a000}, 0xffffffffffffffff)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/index.go:453 +0xcc
go/types.(*Checker).exprInternal(0x14000482540, 0x0, 0x1400053ec00, {0x103340b68, 0x140004a90c0}, {0x0, 0x0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1283 +0xbbc
go/types.(*Checker).rawExpr(0x14000482540, 0x0, 0x1400053ec00, {0x103340b68?, 0x140004a90c0?}, {0x0?, 0x0?}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:981 +0x120
go/types.(*Checker).expr(0x14000482540, 0x0?, 0x1400053ec00, {0x103340b68?, 0x140004a90c0?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/expr.go:1549 +0x38
go/types.(*Checker).varDecl(0x14000482540, 0x14000608180, {0x140006060e8, 0x1, 0x1}, {0x0, 0x0}, {0x103340b68, 0x140004a90c0})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:513 +0x140
go/types.(*Checker).objDecl(0x14000482540, {0x103343af8, 0x14000608180}, 0x0)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/decl.go:188 +0x7e0
go/types.(*Checker).packageObjects(0x14000482540)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/resolver.go:714 +0x3f0
go/types.(*Checker).checkFiles(0x14000482540, {0x1400049c000, 0x1, 0x1})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:459 +0x190
go/types.(*Checker).Files(0x1400018e0e0?, {0x1400049c000?, 0x14000496060?, 0x6?})
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/go/types/check.go:422 +0x80
golang.org/x/tools/go/packages.(*loader).loadPackage(0x1400018e0e0, 0x1400019d710)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:1037 +0x76c
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1()
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:847 +0x178
sync.(*Once).doSlow(0x0?, 0x0?)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:76 +0xf8
sync.(*Once).Do(...)
	/opt/homebrew/Cellar/go/1.23.3/libexec/src/sync/once.go:67
golang.org/x/tools/go/packages.(*loader).loadRecursive(0x0?, 0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:835 +0x48
golang.org/x/tools/go/packages.(*loader).loadRecursive.func1.1(0x0?)
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:842 +0x30
created by golang.org/x/tools/go/packages.(*loader).loadRecursive.func1 in goroutine 8
	/Users/Oleksandr_Redko/go/pkg/mod/golang.org/x/tools@v0.3.0/go/packages/packages.go:841 +0x84
FAIL	github.com/curioswitch/go-reassign/internal/analyzer	0.654s
FAIL

```

</p>
</details> 